### PR TITLE
update: deploy script

### DIFF
--- a/_script/deploy.sh
+++ b/_script/deploy.sh
@@ -18,10 +18,6 @@ echo "[[DEPLOY SYSTEM]] Starting Deployment"
 docker-compose build $STAGE
 docker-compose push $STAGE
 
-# if [[ $STAGE == 'development' ]]; then
-#     fargate service deploy $PACKAGE_NAME-dev --cluster $CLUSTER_NAME --region ap-northeast-2 --image $ECR_DOMAIN/$PACKAGE_NAME:$STAGE
-# elif [[ $STAGE == 'production' ]]; then
-#     fargate service deploy $PACAKGE_NAME-prd --cluster $CLUSTER_NAME --region ap-northeast-2 --image $ECR_DOMAIN/$PACKAGE_NAME:$STAGE
-# fi
+aws ecs update-service --cluster $CLUSTER_NAME --service "wechicken-$STAGE" --force-new-deployment &
 
 echo "[[DEPLOY SYSTEM]] End Deployment"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       <<: *BUILD_OPTION
       args: *ARGS
     ports:
-      - '8090:3000'
+      - '8090:80'
     depends_on:
       - database
     command: ['./wait-for-it.sh', 'database:3306', '--', 'npm', 'run', 'start:prod']

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "deploy": "npm run build && bash _script/deploy.sh"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY _script/wait-for-it.sh .
 COPY dist .
+COPY package-lock.json .
 COPY package.json .
 
 RUN chmod +x wait-for-it.sh
@@ -13,6 +14,6 @@ ARG STAGE
 
 ENV STAGE $STAGE
 
-EXPOSE 3000
+EXPOSE 80
 
 CMD [ "npm", "run", "start:prod" ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(80);
 }
 bootstrap();


### PR DESCRIPTION
# Update
  - _script/deploy.sh 에 fargate 배포 스크립트 추가했습니다. 
  - 보안그룹 때문에 포트를 80 포트로 변경하도록 하겠습니다 @Jun4928 @dhgh95 
 
# Todo
  - github action 에 production 추가
  - secrets 에 aws credential 추가
  - 새로운 레포지토리에 terraform 소스 코드 추가

# 인프라 현재 진행 상황 공유
  - ECR 에 이미지 업로드 가능합니다. (현재 `development` 만 가능, `production`은 추후)
  - ECS 에서 fargate 로 개발 서버 운영 가능합니다. (typeorm 등 DB 미적용)