### PR TITLE
Add: response interceptor (snake_case => camelCase)

### DIFF
--- a/src/blogs/blogs.controller.ts
+++ b/src/blogs/blogs.controller.ts
@@ -10,10 +10,12 @@ import {
   Put,
   Query,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ValidUser } from 'src/auth/decorator/ValidUser';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { BookmarksService } from 'src/bookmarks/bookmarks.service';
+import { CamelCaseInterceptor } from 'src/interceptors/CamelCaseInterceptor';
 import { LikesService } from 'src/likes/likes.service';
 import { User } from 'src/users/user.entity';
 import { BlogsService } from './blogs.service';
@@ -21,6 +23,7 @@ import { BlogSearchInput } from './dto/input/blog-search.input';
 import { CreateBlogInput } from './dto/input/create-blog.input';
 import { UpdateBlogInput } from './dto/input/update-blog.input';
 
+@UseInterceptors(CamelCaseInterceptor)
 @Controller('blogs')
 export class BlogsController {
   constructor(

--- a/src/interceptors/CamelCaseInterceptor.ts
+++ b/src/interceptors/CamelCaseInterceptor.ts
@@ -1,0 +1,60 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface Response<T> {
+  data: T;
+}
+
+const isObject = (v: any): boolean => {
+  return v !== null && typeof v === 'object' && v.constructor === Object;
+};
+
+const isArray = (v: any): boolean => Array.isArray(v);
+
+const object = (acc: Record<string, any>, [k, v]: [string, any]) => ({
+  ...acc,
+  [k]: v,
+});
+
+const toCamelCase = (key: string): string => {
+  return key
+    .toLowerCase()
+    .replace(/[_][a-z]/g, (match) => match.toUpperCase().replace('_', ''));
+};
+
+@Injectable()
+export class CamelCaseInterceptor<T>
+  implements NestInterceptor<T, Response<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<Response<T>> {
+    const keyToCamelcase = ([k, v]: [string, any]): [string, any] => {
+      return isObject(v)
+        ? [toCamelCase(k), deepObjectKeysToCalmelCase(v)]
+        : [toCamelCase(k), v];
+    };
+
+    const deepObjectKeysToCalmelCase = (
+      data: Record<string, any>,
+    ): Record<string, any> => {
+      return Object.entries(data).map(keyToCamelcase).reduce(object, {});
+    };
+
+    const transformDataToCamelCase = (data: any) => {
+      if (isArray(data)) return data.map(deepObjectKeysToCalmelCase);
+      if (isObject(data)) return deepObjectKeysToCalmelCase(data);
+    };
+
+    return next
+      .handle()
+      .pipe(map((data) => ({ data: transformDataToCamelCase(data) })));
+  }
+}


### PR DESCRIPTION
새벽에 갑자기 삘받아서,, 리스폰스 가로채서 
서비스 로직에서 그대로 리턴되는 snake_case 의 키 값들을 camelCase 로 바꾸는 인터셉터 작성했습니다.

아래와 같은 보조함수들을 어떻게 관리하는게 좋을까요?
일단 클래스 상단에 따로 빼 놓았습니다.
 ```ts
const isObject = (v: any): boolean => {
  return v !== null && typeof v === 'object' && v.constructor === Object;
};

const isArray = (v: any): boolean => Array.isArray(v);

const object = (acc: Record<string, any>, [k, v]: [string, any]) => ({
  ...acc,
  [k]: v,
});

const toCamelCase = (key: string): string => {
  return key
    .toLowerCase()
    .replace(/[_][a-z]/g, (match) => match.toUpperCase().replace('_', ''));
};
```

### camelCase 인터셉트 로직
- `transformDataToCamelCase` 가 최초로 호출되고, 배열인지 객체인지 체크해서 실제 로직이 담긴 deepObjectKeysToCalmelCase 를 호출 합니다.
- deepObjectKeysToCalmelCase 는 객체 안에 객체가 중첩되어 있는 객체의 모든 키값을 카멜케이스로 다루도록 작성했습니다. 
- Object.entries 로 [key, value]튜플이 담긴 배열로 만들고, keyToCamelCase 를 호출합니다.
- value 가 여전히 객체면 다시 deepObjectKeysToCamelCase 를 호출해서 객체가 아닐 때까지 파고 들어가도록 재귀 호출을 합니다.

```ts
  intercept(
    context: ExecutionContext,
    next: CallHandler,
  ): Observable<Response<T>> {
    const keyToCamelCase = ([k, v]: [string, any]): [string, any] => {
      return isObject(v)
        ? [toCamelCase(k), deepObjectKeysToCalmelCase(v)]
        : [toCamelCase(k), v];
    };

    const deepObjectKeysToCalmelCase = (
      data: Record<string, any>,
    ): Record<string, any> => {
      return Object.entries(data).map(keyToCamelCase).reduce(object, {});
    };

    const transformDataToCamelCase = (data: any) => {
      if (isArray(data)) return data.map(deepObjectKeysToCalmelCase);
      if (isObject(data)) return deepObjectKeysToCalmelCase(data);
    };

    return next
      .handle()
      .pipe(map((data) => ({ data: transformDataToCamelCase(data) })));
  }
```