### PR TITLE
Fix: entities createForeignkey option | blog_types | blogs earch API

### DIFF
--- a/src/batches/batch-type.entity.ts
+++ b/src/batches/batch-type.entity.ts
@@ -11,8 +11,6 @@ export class BatchType {
   @Column({ type: 'varchar', unique: true })
   name: BatchTypeName;
 
-  @OneToMany(() => Batch, (batch) => batch.batchType, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Batch, (batch) => batch.batchType)
   batches: Batch[];
 }

--- a/src/batches/batch.entity.ts
+++ b/src/batches/batch.entity.ts
@@ -40,18 +40,14 @@ export class Batch {
   @Column({ type: 'datetime', nullable: true })
   deleted_at: Date;
 
-  @ManyToOne(() => BatchType, (batchType) => batchType.batches, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => BatchType, (batchType) => batchType.batches)
   @JoinColumn({ name: 'batch_type_id' })
   batchType: BatchType;
 
   @Column()
   batch_type_id: number;
 
-  @OneToMany(() => User, (user) => user.batch, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => User, (user) => user.batch)
   users: User[];
 
   @Column({ nullable: true, comment: '치킨계장 user.id' })

--- a/src/batches/batch.repository.ts
+++ b/src/batches/batch.repository.ts
@@ -66,11 +66,13 @@ export class BatchRepository extends Repository<Batch> {
         'blog.title',
         'blog.link',
         'blog.written_date',
+        'blog_type.name',
       ])
       .innerJoin('batch.users', 'user', 'user.batch_id = :batch_id', {
         batch_id,
       })
       .innerJoin('user.blogs', 'blog')
+      .leftJoin('user.blogType', 'blog_type')
       .where('blog.written_date BETWEEN :from AND :to', { from, to })
       .getRawMany();
   }

--- a/src/blogs/blog-type.entity.ts
+++ b/src/blogs/blog-type.entity.ts
@@ -11,8 +11,6 @@ export class BlogType {
   @Column({ type: 'varchar', unique: true })
   name: BlogTypeName;
 
-  @OneToMany(() => User, (user) => user.blogType, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => User, (user) => user.blogType)
   users: User[];
 }

--- a/src/blogs/blog.entity.ts
+++ b/src/blogs/blog.entity.ts
@@ -42,24 +42,16 @@ export class Blog {
   @Column({ type: 'datetime', nullable: true })
   deleted_at: Date;
 
-  @OneToMany(() => Bookmark, (bookmark) => bookmark.blog, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Bookmark, (bookmark) => bookmark.blog)
   bookmarks: Bookmark[];
 
-  @OneToMany(() => Like, (like) => like.blog, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Like, (like) => like.blog)
   likes: Like[];
 
-  @OneToMany(() => Tag, (tag) => tag.blog, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Tag, (tag) => tag.blog)
   tags: Tag[];
 
-  @ManyToOne(() => User, (user) => user.blogs, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => User, (user) => user.blogs)
   @JoinColumn({ name: 'user_id' })
   user: User;
 

--- a/src/blogs/blog.repository.ts
+++ b/src/blogs/blog.repository.ts
@@ -29,14 +29,16 @@ export class BlogRepository extends Repository<Blog> {
         'blog',
         'user.id',
         'user.name',
+        'blog_type.name',
         'batch.nth',
-        'batchType.name',
+        'batch_type.name',
         'bookmark.status',
         'like.status',
       ])
       .innerJoin('blog.user', 'user')
       .innerJoin('user.batch', 'batch')
-      .innerJoin('batch.batchType', 'batchType')
+      .leftJoin('user.blogType', 'blog_type')
+      .innerJoin('batch.batchType', 'batch_type')
       .leftJoin('blog.bookmarks', 'bookmark', 'bookmark.user_id = :user_id', {
         user_id,
       })

--- a/src/bookmarks/bookmark.entity.ts
+++ b/src/bookmarks/bookmark.entity.ts
@@ -13,15 +13,11 @@ export class Bookmark {
   @Column({ type: 'boolean' })
   status: boolean;
 
-  @ManyToOne(() => User, (user) => user.bookmarks, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => User, (user) => user.bookmarks)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @ManyToOne(() => Blog, (blog) => blog.bookmarks, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => Blog, (blog) => blog.bookmarks)
   @JoinColumn({ name: 'blog_id' })
   blog: Blog;
 }

--- a/src/likes/like.entity.ts
+++ b/src/likes/like.entity.ts
@@ -13,15 +13,11 @@ export class Like {
   @Column({ type: 'boolean' })
   status: boolean;
 
-  @ManyToOne(() => User, (user) => user.likes, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => User, (user) => user.likes)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @ManyToOne(() => Blog, (blog) => blog.likes, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => Blog, (blog) => blog.likes)
   @JoinColumn({ name: 'blog_id' })
   blog: Blog;
 }

--- a/src/tags/tag.entity.ts
+++ b/src/tags/tag.entity.ts
@@ -13,15 +13,11 @@ export class Tag {
   @Column()
   name: string;
 
-  @ManyToOne(() => User, (user) => user.tags, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => User, (user) => user.tags)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @ManyToOne(() => Blog, (blog) => blog.tags, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => Blog, (blog) => blog.tags)
   @JoinColumn({ name: 'blog_id' })
   blog: Blog;
 }

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -52,24 +52,18 @@ export class User {
   @Column({ type: 'datetime', nullable: true })
   deleted_at: Date;
 
-  @ManyToOne(() => Batch, (batch) => batch.users, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => Batch, (batch) => batch.users)
   @JoinColumn({ name: 'batch_id' })
   batch: Batch;
 
   @Column()
   batch_id: number;
 
-  @ManyToOne(() => BlogType, (blogType) => blogType.users, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToOne(() => BlogType, (blogType) => blogType.users)
   @JoinColumn({ name: 'blog_type_id' })
   blogType: BlogType;
 
-  @ManyToMany(() => User, (user) => user.following, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToMany(() => User, (user) => user.following)
   @JoinTable({
     name: 'follow',
     joinColumn: {
@@ -81,28 +75,18 @@ export class User {
   })
   followers: User[];
 
-  @ManyToMany(() => User, (user) => user.followers, {
-    createForeignKeyConstraints: false,
-  })
+  @ManyToMany(() => User, (user) => user.followers)
   following: User[];
 
-  @OneToMany(() => Bookmark, (bookmark) => bookmark.user, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Bookmark, (bookmark) => bookmark.user)
   bookmarks: Bookmark[];
 
-  @OneToMany(() => Like, (like) => like.user, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Like, (like) => like.user)
   likes: Like[];
 
-  @OneToMany(() => Tag, (tag) => tag.user, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Tag, (tag) => tag.user)
   tags: Tag[];
 
-  @OneToMany(() => Blog, (blog) => blog.user, {
-    createForeignKeyConstraints: false,
-  })
+  @OneToMany(() => Blog, (blog) => blog.user)
   blogs: Blog[];
 }


### PR DESCRIPTION
스키마 싱크, DB 적재 
스크립트 파일이 완성됨에 따라 다음 세가지 내용에 대해서 변경사항을 적용합니다. 
- 모든 엔티티의 `createForeignkeyContstraints: false` 옵션을 삭제했습니다. 
`TypeORM sync: false` 로 업데이트 되었기 때문에
- 스크립트 파일이 완성됨에 따라, blog_type 을 내려주는 API 에 user 와 leftJoin 을 걸어서 blog_type 을 내려주도록 repository 메소드를 변경했습니다.
- blogs 검색 조건에 해당하지 않는 쿼리 파라미터가 들어올 경우 에러를 내도록 blogsService 코드를 수정했습니다.